### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,4 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.5)
       actionpack (= 6.0.3.5)
       activesupport (= 6.0.3.5)
@@ -326,6 +329,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,9 +16,9 @@ class Item < ApplicationRecord
     validates :title
     validates :details
     validates :images
-    validates :price,numericality: {with:/\A[0-9]+\z/,message:"must be half integer"},inclusion: { in: 300..9_999_999,message:"is beyond acceptable limits" }
+    validates :price,numericality: {with:/\A[0-9]+\z/,message:"は半角数字でないと登録できません"},inclusion: { in: 300..9_999_999,message:"が許容範囲を超えています" }
 
-    with_options numericality: { other_than: 1 }  do
+    with_options numericality: { other_than: 1,message:"を選択してください" }  do
     validates :category_id
     validates :condition_id
     validates :shipping_fee_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,17 +8,17 @@ class User < ApplicationRecord
          validates :nickname
          validates :birth_date
 
-         with_options format: { with: /\A[ぁ-ゔァ-ヴ\p{Ideographic}ａ-ｚＡ-Ｚ０-９]+\z/,message:"must be full-pitch character"} do
+         with_options format: { with: /\A[ぁ-ゔァ-ヴ\p{Ideographic}ａ-ｚＡ-Ｚ０-９]+\z/,message:"は全角でなければ登録できません"} do
          validates :family_name
          validates :first_name
          end
 
-         with_options format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/,message:"must be full-width katakana"} do
+         with_options format: { with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/,message:"は全角カタカナでないと登録できません"} do
          validates :family_name_kana
          validates :first_name_kana
          end
          
-         validates :password, format:{with: /(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{6,}/,message:"include both letters and numbers"}
+         validates :password, format:{with: /(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{6,}/,message:"は英数混合でなければ登録できません"}
         end
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Furima34435
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+   config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
+        message_unconfirmed:
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,25 @@
+ja:
+ activerecord:
+   attributes:
+
+    
+
+     user:
+       nickname: ニックネーム
+       family_name: 姓
+       first_name: 名
+       family_name_kana: 姓（カナ）
+       first_name_kana: 名（カナ）
+       birth_date: 誕生日
+       
+     item:
+       title: 商品名
+       category_id: カテゴリー
+       condition_id: 商品状態
+       price: 料金
+       details: 詳細欄
+       shipping_fee_id: 配送料
+       prefecture_id: 都道府県
+       shipping_date_id: 発送までの日数
+       images: 画像
+

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     association :user
 
     after(:build) do |item|
-      item.image.attach(io: File.open('app/assets/images/star.png'), filename: 'star.png')
+      item.images.attach(io: File.open('app/assets/images/star.png'), filename: 'star.png')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,72 +32,72 @@ RSpec.describe Item, type: :model do
     it '商品名が空では登録できない' do
       @item.title = ''
       @item.valid?
-      expect(@item.errors.full_messages).to include("Title can't be blank")
+      expect(@item.errors.full_messages).to include("商品名を入力してください")
     end
     it '詳細が空では登録できない' do
       @item.details = ''
       @item.valid?
-      expect(@item.errors.full_messages).to include("Details can't be blank")
+      expect(@item.errors.full_messages).to include("詳細欄を入力してください")
     end
-    it 'imageがないと出品できない' do
-      @item.image = nil
+    it 'sがないと出品できない' do
+      @item.images = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
+      expect(@item.errors.full_messages).to include("画像を入力してください")
     end
     it 'カテゴリーidが1では登録できない' do
       @item.category_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include("Category must be other than 1")
+      expect(@item.errors.full_messages).to include("カテゴリーを選択してください")
     end
     it 'コンディションidが1では登録できない' do
       @item.condition_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include("Condition must be other than 1")
+      expect(@item.errors.full_messages).to include("商品状態を選択してください")
     end
     it '都道府県idが1では登録できない' do
       @item.prefecture_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+      expect(@item.errors.full_messages).to include("都道府県を選択してください")
     end
     it '配送料idが1では登録できない' do
       @item.shipping_fee_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping fee must be other than 1")
+      expect(@item.errors.full_messages).to include("配送料を選択してください")
     end
     it '発送日idが1では登録できない' do
       @item.shipping_date_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping date must be other than 1")
+      expect(@item.errors.full_messages).to include("発送までの日数を選択してください")
     end
     it '商品価格が空では登録できない' do
       @item.price = ''
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price can't be blank")
+      expect(@item.errors.full_messages).to include("料金を入力してください")
     end
     it 'priceが300円以下だと出品できない' do
       @item.price = 299
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price is beyond acceptable limits")
+      expect(@item.errors.full_messages).to include("料金が許容範囲を超えています")
     end
     it 'priceが9,999,999円以上だと出品できない' do
       @item.price = 10_000_000
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price is beyond acceptable limits")
+      expect(@item.errors.full_messages).to include("料金が許容範囲を超えています")
     end
     it '商品価格は全角数字では登録できない' do
       @item.price = '３００'
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be half integer")
+      expect(@item.errors.full_messages).to include("料金は半角数字でないと登録できません")
     end
     it '商品価格は半角英数字混合では登録できない' do
       @item.price = "300dollers"
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be half integer")
+      expect(@item.errors.full_messages).to include("料金は半角数字でないと登録できません")
     end
     it '商品価格は半角英字のみでは登録できない' do
       @item.price = "one-thousand dollers"
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be half integer")
+      expect(@item.errors.full_messages).to include("料金は半角数字でないと登録できません")
     end
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,109 +36,109 @@ RSpec.describe User, type: :model do
     it 'nicknameが空では登録できない' do
       @user.nickname = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      expect(@user.errors.full_messages).to include("ニックネームを入力してください")
     end
     it "emailが空では登録できない" do
       @user.email = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include("Email can't be blank")
+      expect(@user.errors.full_messages).to include("Eメールを入力してください")
     end
     it '重複したemailが存在する場合登録できない' do
       @user.save
       another_user = FactoryBot.build(:user)
       another_user.email = @user.email
       another_user.valid?
-      expect(another_user.errors.full_messages).to include('Email has already been taken')
+      expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
     end
     it "emailには@が含まれていないと登録できない" do
       @user.email = "example.gmail.com"
       @user.valid?
-      expect(@user.errors.full_messages).to include("Email is invalid")
+      expect(@user.errors.full_messages).to include("Eメールは不正な値です")
     end
     it "名字が空では登録できない" do
       @user.family_name = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include("Family name can't be blank")
+      expect(@user.errors.full_messages).to include("姓を入力してください")
     end
     it "名字が全角でないと登録できない" do
       @user.family_name = "aka"
       @user.valid?
-      expect(@user.errors.full_messages).to include("Family name must be full-pitch character")
+      expect(@user.errors.full_messages).to include("姓は全角でなければ登録できません")
     end
     it "名前が空では登録できない" do
       @user.first_name = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name can't be blank")
+      expect(@user.errors.full_messages).to include("名を入力してください")
     end
     it "名前は全角でないと登録できない" do
       @user.first_name = "aka"
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name must be full-pitch character")
+      expect(@user.errors.full_messages).to include("名は全角でなければ登録できません")
     end
     it "名字（カナ）が空では登録できない" do
       @user.family_name_kana = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include("Family name kana can't be blank")
+      expect(@user.errors.full_messages).to include("姓（カナ）を入力してください")
     end
     it "名字（カナ）は全角カタカナでないと登録できない" do
       @user.family_name_kana = "赤"
       @user.valid?
-      expect(@user.errors.full_messages).to include("Family name kana must be full-width katakana")
+      expect(@user.errors.full_messages).to include("姓（カナ）は全角カタカナでないと登録できません")
     end
     it "名前（カナ）が空では登録できない" do
       @user.first_name_kana = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana can't be blank")
+      expect(@user.errors.full_messages).to include("名（カナ）を入力してください")
     end
     it "名前（カナ）は全角カタカナでないと登録できない" do
       @user.first_name_kana = "赤"
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name kana must be full-width katakana")
+      expect(@user.errors.full_messages).to include("名（カナ）は全角カタカナでないと登録できません")
     end
     it "passwordが空では登録できない" do
       @user.password = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password can't be blank")
+      expect(@user.errors.full_messages).to include("パスワードを入力してください")
     end
     it "passwordが存在してもpassword_confirmationが空では登録できない" do
       @user.password_confirmation = ""
       @user.valid?
-      expect(@user.errors.full_messages).to include"Password confirmation doesn't match Password"
+      expect(@user.errors.full_messages).to include"パスワード（確認用）とパスワードの入力が一致しません"
     end
     it 'passwordとpassword_confirmationが不一致では登録できないこと' do
       @user.password = 'pass00'
       @user.password_confirmation = 'pass001'
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
     end
     it 'passwordが5文字以下では登録できない' do
       @user.password = "3d3"
       @user.password_confirmation = "3d3"
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+      expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
     end
 
     it 'passwordが6文字以上でも数字のみでは登録できない' do
       @user.password = "000000"
       @user.password_confirmation = "000000"
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password include both letters and numbers")
+      expect(@user.errors.full_messages).to include("パスワードは英数混合でなければ登録できません")
    end
    it 'passwordが6文字以上でも英字のみでは登録できない' do
     @user.password = "aaaaaa"
     @user.password_confirmation = "aaaaaa"
     @user.valid?
-    expect(@user.errors.full_messages).to include("Password include both letters and numbers")
+    expect(@user.errors.full_messages).to include("パスワードは英数混合でなければ登録できません")
    end
    it "passwordが全角の場合は登録できない" do
     @user.password = "ｐｔｋ００１"
     @user.valid?
-    expect(@user.errors.full_messages).to include("Password include both letters and numbers")
+    expect(@user.errors.full_messages).to include("パスワードは英数混合でなければ登録できません")
   end
    it "生年月日が空では登録できない" do
     @user.birth_date = ""
     @user.valid?
-    expect(@user.errors.full_messages).to include("Birth date can't be blank")
+    expect(@user.errors.full_messages).to include("誕生日を入力してください")
   end
 
   


### PR DESCRIPTION
# WHAT
ユーザー登録時、もしくは商品出品時に表示されるエラーメッセージの日本語化

# WHY
情報登録時にエラーが生じた場合、エラー内容が全て日本語表記になっているか確認するため